### PR TITLE
BUG: audit log

### DIFF
--- a/README
+++ b/README
@@ -1,18 +1,13 @@
-Linux kernel
-============
+Linux Kernel Audit Subsystem
+=============================================================================
+https://git.kernel.org/pub/scm/linux/kernel/git/pcmoore/audit.git
+https://github.com/linux-audit/audit-kernel
 
-There are several guides for kernel developers and users. These guides can
-be rendered in a number of formats, like HTML and PDF. Please read
-Documentation/admin-guide/README.rst first.
+The original Linux Kernel README file:
+* https://github.com/linux-audit/audit-kernel/blob/main/README.orig
 
-In order to build the documentation, use ``make htmldocs`` or
-``make pdfdocs``.  The formatted documentation can also be read online at:
+The Linux Kernel audit subsystem README.md file:
+* https://github.com/linux-audit/audit-kernel/blob/main/README.md
 
-    https://www.kernel.org/doc/html/latest/
-
-There are various text files in the Documentation/ subdirectory,
-several of them using the Restructured Text markup notation.
-
-Please read the Documentation/process/changes.rst file, as it contains the
-requirements for building and running the kernel, and information about
-the problems which may result by upgrading your kernel.
+The latest official Linux Kernel documentation:
+* https://www.kernel.org/doc/html/latest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+Linux Kernel Audit Subsystem
+=============================================================================
+https://git.kernel.org/pub/scm/linux/kernel/git/pcmoore/audit.git
+https://github.com/linux-audit/audit-kernel
+
+The Linux Audit subsystem provides a secure logging framework that is used to
+capture and record security relevant events.  It consists of a kernel component
+which generates audit records based on system activity, a userspace daemon
+which logs these records to a local file or a remote aggregation server, and a
+set of userspace tools to for audit log inspection and post-processing.
+
+The main Linux Kernel README can be found at
+[Documentation/admin-guide/README.rst](./Documentation/admin-guide/README.rst)
+
+## Online Resources
+
+The canonical audit kernel repository is hosted by kernel.org:
+
+* https://git.kernel.org/pub/scm/linux/kernel/git/pcmoore/audit.git
+* git://git.kernel.org/pub/scm/linux/kernel/git/pcmoore/audit.git
+
+There is also an officially maintained GitHub mirror:
+
+* https://github.com/linux-audit/audit-kernel
+
+## Kernel Tree Process
+
+After the merge window closes upstream, a decision will be made regarding the
+need to rebase the next branch on top of the current Linux -rc1 release. If
+there have been a number of subsystem related changes outside of the
+subsystem's next branch, or if the branch's base is too far behind
+linux/master, it may be necessary to rebase the next branch. If a rebase is
+needed, it should be done before any patches are merged, and rebasing the next
+branch during the remaining -rcX releases should only be done in extreme cases.
+
+Patches will be merged into the subsystem's next branch during the development
+cycle which extends from merge window close up until the merge window reopens.
+However, it is important to note that large, complicated, or invasive patches
+sent late in the development cycle may be deferred until the next cycle. As a
+general rule, only small patches or critical fixes will be merged after
+-rc5/-rc6.
+
+Any patches deemed necessary for the current Linux -rcX releases will be merged
+into the current stable-X.Y branch, marked with a signed tag, and a pull
+request sent against linux/master as soon as it is reasonable to do so.
+
+During the development cycle Fedora Rawhide test kernels will be generated
+using the next and most recent stable-X.Y branches on a weekly basis, if not
+more often. These kernels will be tested against the SELinux test suite and
+audit test suite as well as being made available to everyone for additional
+testing.
+
+Once the merge window opens, the next branch will be copied to a new branch,
+stable-X.Y, and the branch will be marked with a signed tag in the format
+audit-pr-YYYYMMDD. A pull request will be sent against the linux/master
+branch using the signed tag.
+
+## Userspace Tools and Test Suites
+
+The audit userspace tools and test suites are hosted by GitHub:
+
+* https://github.com/linux-audit

--- a/README.orig
+++ b/README.orig
@@ -1,0 +1,18 @@
+Linux kernel
+============
+
+There are several guides for kernel developers and users. These guides can
+be rendered in a number of formats, like HTML and PDF. Please read
+Documentation/admin-guide/README.rst first.
+
+In order to build the documentation, use ``make htmldocs`` or
+``make pdfdocs``.  The formatted documentation can also be read online at:
+
+    https://www.kernel.org/doc/html/latest/
+
+There are various text files in the Documentation/ subdirectory,
+several of them using the Restructured Text markup notation.
+
+Please read the Documentation/process/changes.rst file, as it contains the
+requirements for building and running the kernel, and information about
+the problems which may result by upgrading your kernel.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+Audit Kernel Subsystem Security Policy
+=============================================================================
+
+The audit kernel developers take security very seriously and if you think you
+have found a serious problem or security vulnerability in the audit kernel
+code you are encouraged to send email to the current audit kernel maintainer
+who is listed below:
+
+* Paul Moore, paul@paul-moore.com
+
+## Linux Kernel General Security Policy
+
+In addition to the contact information above, the Linux Kernel also has a
+security policy documented in the link below:
+
+* https://github.com/linux-audit/audit-kernel/blob/main/Documentation/admin-guide/security-bugs.rst


### PR DESCRIPTION
fix:audit.log can't record correctly when rm the dir end with '/'

step:

1. mkdir test

2. touch test/111.txt

3. rm -r test/

Log:

type=PATH msg=audit(1690506313.361:2505): **item=1 name=(null)** inode=1049357 dev=fc:03 mode=040755 ouid=1000 ogid=1000 rdev=00:00 obj=unconfined_u:object_r:user_home_t:s0 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0

type=PATH msg=audit(1690506313.361:2505): **item=2 name=(null)** inode=1049384 dev=fc:03 mode=040775 ouid=1000 ogid=1000 rdev=00:00 obj=unconfined_u:object_r:user_home_t:s0 nametype=DELETE cap_fp=0 cap_fi=0 cap_fe=0

Change-Id: I6b242a062ced1e3db129b9b9e5f155c681561c2a